### PR TITLE
土曜日を青色、日曜日を赤色で表示

### DIFF
--- a/src/calendar/Calendar.css
+++ b/src/calendar/Calendar.css
@@ -32,8 +32,11 @@ Copyright © 2016 Toru Takahahshi. All rights reserved.
 .date-picker-popup > * > .today.selected {
     -fx-background-color: -fx-selection-bar, derive(-fx-selection-bar-non-focused, -20%), -fx-selection-bar;
 }
-/*
-.date-picker-popup > * > .today:focused {
-    -fx-background-color: -fx-control-inner-background, -fx-cell-focus-inner-border, -fx-control-inner-background;
+/* 土曜日の文字色の設定 */
+.date-picker-popup > * > .day-cell.saturday {
+    -fx-text-fill: dodgerblue;
 }
-*/
+/* 日曜日の文字色の設定 */
+.date-picker-popup > * > .day-cell.sunday {
+    -fx-text-fill: mediumvioletred;
+}

--- a/src/calendar/Calendar.java
+++ b/src/calendar/Calendar.java
@@ -4,12 +4,16 @@
 package calendar;
 
 import com.sun.javafx.scene.control.skin.DatePickerSkin;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Locale;
 import java.util.Map;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.Scene;
+import javafx.scene.control.DateCell;
 import javafx.scene.control.DatePicker;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
@@ -24,10 +28,20 @@ public class Calendar extends Application {
     
     @Override
     public void start(Stage primaryStage) {
+        // コマンドライン引数の解析
         stage = primaryStage;
         parseParameters();
-        DatePickerSkin datePickerSkin = new DatePickerSkin(new DatePicker(LocalDate.now()));
-        Node calendar = datePickerSkin.getPopupContent();
+
+        DatePicker datePicker = new DatePicker(LocalDate.now());
+        datePicker.setDayCellFactory(picker -> new DateCell() {
+            @Override
+            public void updateItem(LocalDate item, boolean empty) {
+                super.updateItem(item, empty);
+                System.out.println("styleClass=" + this.getStyleClass());
+                getStyleClass().add(DayOfWeek.from(item).getDisplayName(TextStyle.FULL, Locale.US).toLowerCase());
+            }
+        });
+        Node calendar = new DatePickerSkin(datePicker).getPopupContent();
         
         StackPane root = new StackPane();
         root.getChildren().add(calendar);


### PR DESCRIPTION
- DateCellを生成する際、CSSスタイルクラスに曜日名を追加し、CSS側で曜日によって色を変更できるように修正
- CSSで土曜日の文字を青系、日曜日の色を赤系に定義
